### PR TITLE
Add secure file transfer facility via GCS signed URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,116 @@
 # secure-file-transfer
-Secure file transfer using Google Load Balancer and Google Cloud Storage
+
+Disposable file-sharing using Google Cloud Storage signed URLs — spin up, upload, share, tear down.
+
+## How it works
+
+1. `terraform apply` — provisions a private GCS bucket and a signing service account
+2. `transfer.py upload` — uploads a file and returns a time-limited signed URL
+3. Share the URL with the customer; clicking it triggers an immediate download
+4. `terraform destroy` — removes all infrastructure and files
+
+Signed URLs are served directly from `storage.googleapis.com`, which enforces TLS 1.2 / 1.3 and strong ECDHE cipher suites. No service-account key file is ever created.
+
+---
+
+## Prerequisites
+
+- `terraform` >= 1.5
+- `gcloud` CLI authenticated: `gcloud auth application-default login`
+- Python 3.9+
+- GCP project with these APIs enabled:
+  ```bash
+  gcloud services enable storage.googleapis.com \
+      iam.googleapis.com \
+      iamcredentials.googleapis.com
+  ```
+
+---
+
+## Setup
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars — set project_id and your user in signing_sa_members
+
+terraform init
+terraform apply
+```
+
+Note the two outputs:
+```
+bucket_name      = "secure-transfer-a1b2c3d4"
+signing_sa_email = "secure-transfer-signer@my-project.iam.gserviceaccount.com"
+```
+
+Install the Python dependencies once:
+```bash
+cd scripts
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+---
+
+## Usage
+
+### Upload and get a shareable URL
+
+```bash
+python transfer.py upload \
+    --bucket      secure-transfer-a1b2c3d4 \
+    --signing-sa  secure-transfer-signer@my-project.iam.gserviceaccount.com \
+    --file        report.pdf \
+    --expiry      48h
+```
+
+```
+Uploading  report.pdf  →  gs://secure-transfer-a1b2c3d4/report.pdf
+Upload complete.
+
+========================================================================
+Shareable URL (expires 2025-06-15 14:32 UTC):
+
+https://storage.googleapis.com/secure-transfer-a1b2c3d4/report.pdf?X-Goog-...
+========================================================================
+```
+
+Send that URL to your customer. It expires automatically at the requested time.
+
+### List files in the bucket
+
+```bash
+python transfer.py list \
+    --bucket     secure-transfer-a1b2c3d4 \
+    --signing-sa secure-transfer-signer@...
+```
+
+### Delete a file early
+
+```bash
+python transfer.py delete \
+    --bucket     secure-transfer-a1b2c3d4 \
+    --signing-sa secure-transfer-signer@... \
+    --object     report.pdf
+```
+
+---
+
+## Tear down
+
+```bash
+cd terraform
+terraform destroy
+```
+
+All objects and infrastructure are removed.
+
+---
+
+## Security notes
+
+- The bucket has `public_access_prevention = enforced` — objects can never be made public accidentally.
+- Signed URLs are scoped to `GET` only and expire at the requested time (max 7 days).
+- No service-account key file is generated. The script calls the IAM `signBlob` API by impersonating the signing SA using your ADC — revocable at any time via IAM.
+- Files auto-delete after `file_retention_days` (default: 7) even if you forget to clean up.

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-storage>=2.14.0
+google-auth>=2.28.0

--- a/scripts/transfer.py
+++ b/scripts/transfer.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Secure File Transfer — upload a file and generate a shareable signed URL.
+
+Usage
+-----
+  python transfer.py upload \\
+      --file        report.pdf \\
+      --bucket      secure-transfer-xxxx \\
+      --signing-sa  secure-transfer-signer@project.iam.gserviceaccount.com \\
+      --expiry      24h
+
+The caller must be authenticated via Application Default Credentials and must
+have roles/iam.serviceAccountTokenCreator on the signing service account
+(granted by Terraform to the principals listed in signing_sa_members).
+
+No service-account key file is created or needed.
+"""
+
+import argparse
+import datetime
+import mimetypes
+import os
+import pathlib
+import sys
+
+import google.auth
+import google.auth.impersonated_credentials
+import google.auth.transport.requests
+from google.cloud import storage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def parse_expiry(value: str) -> datetime.timedelta:
+    """Parse a human-friendly duration like '24h', '7d', '30m' into a timedelta."""
+    units = {"m": "minutes", "h": "hours", "d": "days"}
+    if not value or not value[-1] in units:
+        raise argparse.ArgumentTypeError(
+            f"Invalid expiry '{value}'. Use a number followed by m/h/d (e.g. 24h, 7d, 30m)."
+        )
+    try:
+        amount = int(value[:-1])
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid expiry '{value}'.")
+    if amount <= 0:
+        raise argparse.ArgumentTypeError("Expiry must be a positive number.")
+    # V4 signed URLs have a maximum lifetime of 7 days
+    td = datetime.timedelta(**{units[value[-1]]: amount})
+    if td > datetime.timedelta(days=7):
+        raise argparse.ArgumentTypeError(
+            "GCS V4 signed URLs cannot exceed 7 days. Use a shorter expiry."
+        )
+    return td
+
+
+def impersonated_storage_client(
+    signing_sa: str,
+    source_credentials,
+) -> storage.Client:
+    """Return a Storage client whose requests are signed by *signing_sa*."""
+    target_creds = google.auth.impersonated_credentials.Credentials(
+        source_credentials=source_credentials,
+        target_principal=signing_sa,
+        target_scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        lifetime=300,
+    )
+    return storage.Client(credentials=target_creds)
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def cmd_upload(args):
+    filepath = pathlib.Path(args.file)
+    if not filepath.exists():
+        sys.exit(f"Error: file not found: {filepath}")
+
+    # Authenticate with ADC (runs as the operator, not the signing SA)
+    source_credentials, project = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+    )
+    source_credentials.refresh(google.auth.transport.requests.Request())
+
+    # Build an impersonated client so the signing SA signs the URL blob
+    client = impersonated_storage_client(args.signing_sa, source_credentials)
+
+    bucket = client.bucket(args.bucket)
+
+    # Preserve directory structure inside the bucket when --prefix is given
+    object_name = (
+        f"{args.prefix.rstrip('/')}/{filepath.name}"
+        if args.prefix
+        else filepath.name
+    )
+
+    blob = bucket.blob(object_name)
+
+    # Detect content type so the browser knows how to handle the file
+    content_type, _ = mimetypes.guess_type(str(filepath))
+    content_type = content_type or "application/octet-stream"
+
+    print(f"Uploading  {filepath}  →  gs://{args.bucket}/{object_name}")
+    blob.upload_from_filename(str(filepath), content_type=content_type)
+    print("Upload complete.")
+
+    expiry = parse_expiry(args.expiry)
+
+    url = blob.generate_signed_url(
+        version="v4",
+        expiration=expiry,
+        method="GET",
+        # Force the browser to download the file rather than display it inline
+        response_disposition=f'attachment; filename="{filepath.name}"',
+        response_type=content_type,
+    )
+
+    expires_at = datetime.datetime.now(datetime.timezone.utc) + expiry
+    print()
+    print("=" * 72)
+    print(f"Shareable URL (expires {expires_at.strftime('%Y-%m-%d %H:%M UTC')}):")
+    print()
+    print(url)
+    print("=" * 72)
+
+
+def cmd_list(args):
+    source_credentials, _ = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+    )
+    client = impersonated_storage_client(args.signing_sa, source_credentials)
+    bucket = client.bucket(args.bucket)
+
+    blobs = list(bucket.list_blobs(prefix=args.prefix or None))
+    if not blobs:
+        print("Bucket is empty.")
+        return
+
+    print(f"{'Object':60s}  {'Size':>12}  {'Updated'}")
+    print("-" * 90)
+    for b in blobs:
+        size = f"{b.size:,}" if b.size is not None else "—"
+        updated = b.updated.strftime("%Y-%m-%d %H:%M UTC") if b.updated else "—"
+        print(f"{b.name:60s}  {size:>12}  {updated}")
+
+
+def cmd_delete(args):
+    source_credentials, _ = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+    )
+    client = impersonated_storage_client(args.signing_sa, source_credentials)
+    bucket = client.bucket(args.bucket)
+    blob = bucket.blob(args.object)
+    blob.delete()
+    print(f"Deleted gs://{args.bucket}/{args.object}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--bucket", required=True,
+        help="GCS bucket name (from Terraform output: bucket_name)",
+    )
+    common.add_argument(
+        "--signing-sa", required=True, dest="signing_sa",
+        help="Signing service account email (from Terraform output: signing_sa_email)",
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Secure File Transfer — upload files and generate signed download URLs",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # upload
+    p_upload = sub.add_parser("upload", parents=[common], help="Upload a file and print a signed URL")
+    p_upload.add_argument("--file", required=True, help="Local file path to upload")
+    p_upload.add_argument(
+        "--expiry", default="24h",
+        help="URL lifetime: number followed by m/h/d (max 7d). Default: 24h",
+    )
+    p_upload.add_argument("--prefix", default="", help="Optional folder prefix inside the bucket")
+
+    # list
+    p_list = sub.add_parser("list", parents=[common], help="List objects in the bucket")
+    p_list.add_argument("--prefix", default="", help="Filter by prefix")
+
+    # delete
+    p_del = sub.add_parser("delete", parents=[common], help="Delete an object from the bucket")
+    p_del.add_argument("--object", required=True, help="Object name to delete")
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    dispatch = {"upload": cmd_upload, "list": cmd_list, "delete": cmd_delete}
+    try:
+        dispatch[args.command](args)
+    except google.auth.exceptions.DefaultCredentialsError:
+        sys.exit(
+            "Error: no Application Default Credentials found.\n"
+            "Run:  gcloud auth application-default login"
+        )
+    except Exception as exc:  # noqa: BLE001
+        sys.exit(f"Error: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,81 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+# ---------------------------------------------------------------------------
+# Private GCS bucket
+# ---------------------------------------------------------------------------
+resource "google_storage_bucket" "transfer" {
+  name                        = "secure-transfer-${random_id.suffix.hex}"
+  location                    = var.region
+  force_destroy               = true          # allows terraform destroy to remove objects
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"    # never accidentally public
+
+  lifecycle_rule {
+    condition {
+      age = var.file_retention_days
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Service account used exclusively for signing download URLs
+# No long-lived key is created; callers impersonate it via the IAM API.
+# ---------------------------------------------------------------------------
+resource "google_service_account" "signer" {
+  account_id   = "secure-transfer-signer"
+  display_name = "Secure Transfer — URL Signer"
+}
+
+# The signing SA needs to read objects in order for a signed URL to be valid
+resource "google_storage_bucket_iam_member" "signer_viewer" {
+  bucket = google_storage_bucket.transfer.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.signer.email}"
+}
+
+# Allow listed humans/SAs to impersonate the signer SA so they can call
+# iam.serviceAccounts.signBlob (used by the Python script for V4 signed URLs)
+resource "google_service_account_iam_member" "token_creators" {
+  for_each           = toset(var.signing_sa_members)
+  service_account_id = google_service_account.signer.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = each.value
+}
+
+# The signing SA also needs to sign its own blobs (self-impersonation path)
+resource "google_service_account_iam_member" "self_signer" {
+  service_account_id = google_service_account.signer.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.signer.email}"
+}
+
+# Allow listed members to upload objects to the bucket
+resource "google_storage_bucket_iam_member" "uploaders" {
+  for_each = toset(var.signing_sa_members)
+  bucket   = google_storage_bucket.transfer.name
+  role     = "roles/storage.objectCreator"
+  member   = each.value
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "Name of the private GCS bucket — pass to transfer.py --bucket"
+  value       = google_storage_bucket.transfer.name
+}
+
+output "signing_sa_email" {
+  description = "Signing service account email — pass to transfer.py --signing-sa"
+  value       = google_service_account.signer.email
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# Copy to terraform.tfvars and fill in your values.
+
+project_id          = "my-gcp-project"
+region              = "US"          # multi-region; use "us-central1" for a single region
+file_retention_days = 7
+
+# IAM members allowed to upload files and generate signed URLs.
+# Format: "user:alice@example.com" or "serviceAccount:sa@project.iam.gserviceaccount.com"
+signing_sa_members = [
+  "user:you@example.com",
+]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,21 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCS bucket location (multi-region or region, e.g. US, EU, us-central1)"
+  type        = string
+  default     = "US"
+}
+
+variable "file_retention_days" {
+  description = "Days after which uploaded files are automatically deleted"
+  type        = number
+  default     = 7
+}
+
+variable "signing_sa_members" {
+  description = "IAM members (e.g. user:you@example.com) allowed to upload files and generate signed URLs"
+  type        = list(string)
+}


### PR DESCRIPTION
## Summary

- Adds Terraform to provision a private GCS bucket and a signing service account (no key file generated)
- Adds `scripts/transfer.py` CLI to upload files and return time-limited V4 signed URLs for customer downloads
- Files auto-delete after a configurable retention period; `terraform destroy` tears everything down cleanly

## How to use

```bash
# Provision
cd terraform && terraform apply

# Upload + share
python scripts/transfer.py upload \
  --bucket      <bucket_name> \
  --signing-sa  <signing_sa_email> \
  --file        report.pdf \
  --expiry      48h

# Tear down
terraform destroy
```

## Test plan

- [ ] `terraform init && terraform apply` completes without errors
- [ ] `transfer.py upload` uploads the file and prints a signed URL
- [ ] Clicking the URL in a browser triggers a file download
- [ ] URL returns 403 after expiry
- [ ] `terraform destroy` removes bucket and all objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)